### PR TITLE
[Fix] #7 - 검색상태에 따라서 UI 표시

### DIFF
--- a/MyBookShelf/MyBookShelf/Features/Search/View/SearchViewController.swift
+++ b/MyBookShelf/MyBookShelf/Features/Search/View/SearchViewController.swift
@@ -1,43 +1,52 @@
 import UIKit
 import SnapKit
 
-class SearchViewController: UIViewController {
+final class SearchViewController: UIViewController {
     
-    // UI 컴포넌트
+    // UI 컴포넌트들
     private let searchBar = UISearchBar()
     private let tableView = UITableView()
     private let emptyLabel = UILabel()
-
+    
+    // 프로퍼티들
+    private var searchResults: [String] = [] {
+        didSet { updateUIState() }
+    }
+    
+    // 라이프싸이클
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
         setupLayout()
+        updateUIState()
     }
 }
 
-// Setup UI
+// UI 셋업
 extension SearchViewController {
+    
     private func setupUI() {
         view.backgroundColor = .systemBackground
         title = "책 검색"
         
-        // 검색바 설정
+        // 검색바
         searchBar.placeholder = "책 제목을 입력하세요"
         searchBar.searchBarStyle = .minimal
+        searchBar.delegate = self
         view.addSubview(searchBar)
         
-        // 테이블뷰 설정
+        // 테이블뷰
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
         tableView.rowHeight = 90
         tableView.separatorStyle = .singleLine
         tableView.backgroundColor = .clear
+        tableView.dataSource = self
         view.addSubview(tableView)
         
-        // 검색 결과 없을 때 라벨
+        // 결과 없음 라벨
         emptyLabel.text = "검색 결과가 없습니다."
         emptyLabel.textColor = .gray
         emptyLabel.textAlignment = .center
-        emptyLabel.isHidden = true
         view.addSubview(emptyLabel)
     }
     
@@ -56,6 +65,50 @@ extension SearchViewController {
         emptyLabel.snp.makeConstraints { make in
             make.center.equalToSuperview()
         }
+    }
+    
+    // UI 상태 업데이트
+    private func updateUIState() {
+        if searchResults.isEmpty {
+            // 검색 전 또는 결과 없음
+            if searchBar.text?.isEmpty == true {
+                // 검색 전
+                tableView.isHidden = true
+                emptyLabel.isHidden = true
+            } else {
+                // 검색 결과 없음
+                tableView.isHidden = true
+                emptyLabel.isHidden = false
+            }
+        } else {
+            // 검색 결과 있음
+            tableView.isHidden = false
+            emptyLabel.isHidden = true
+        }
+    }
+}
+
+// UITableViewDataSource
+extension SearchViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        searchResults.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = searchResults[indexPath.row]
+        return cell
+    }
+}
+
+// UISearchBarDelegate
+extension SearchViewController: UISearchBarDelegate {
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        guard let query = searchBar.text, !query.isEmpty else { return }
+        searchBar.resignFirstResponder()
+        
+        // 이 부분은 다음 단계에서 ViewModel로 연결 예정
+        // viewModel.search(query: query)
     }
 }
 


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!
> 


상태 | tableView | emptyLabel | 설명
| -- | -- | -- | --
검색 전(검색안함) | 숨김 | 숨김 | 초기 상태
검색 결과 있음 | 표시 | 숨김 | 실제 검색 결과 표시 예정
검색 결과 없음 | 숨김 | 표시 | “검색 결과가 없습니다.” 라벨 표시

현재 UI 로직만 있고 
이후 작업에서 카카오 REST API 검색 결과가 테이블에 표시되게 할 예정

### 관련 이슈

Closes #7

### PR 올리기 전 Check List

Merge 대상 브랜치가 올바른가? 네

작업한 코드가 에러 없이 잘 동작하는가? 네
