### PR TITLE
[Feat] #9 - 카카오 책검색 API 연동

### DIFF
--- a/MyBookShelf/MyBookShelf/Features/Search/Model/Book.swift
+++ b/MyBookShelf/MyBookShelf/Features/Search/Model/Book.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct Book: Codable {
+    let title: String
+    let authors: [String]
+    let publisher: String
+    let thumbnail: String?
+    let contents: String?
+}
+
+struct BookSearchResponse: Codable {
+    let documents: [Book]
+}

--- a/MyBookShelf/MyBookShelf/Features/Search/View/SearchViewController.swift
+++ b/MyBookShelf/MyBookShelf/Features/Search/View/SearchViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import SnapKit
 
-final class SearchViewController: UIViewController {
+class SearchViewController: UIViewController {
     
     // UI 컴포넌트들
     private let searchBar = UISearchBar()
@@ -107,8 +107,20 @@ extension SearchViewController: UISearchBarDelegate {
         guard let query = searchBar.text, !query.isEmpty else { return }
         searchBar.resignFirstResponder()
         
-        // 이 부분은 다음 단계에서 ViewModel로 연결 예정
-        // viewModel.search(query: query)
+        // 네트워크 호출
+        BookService.shared.searchBooks(query: query) { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let books):
+                    // 검색 결과를 문자열로 변환 (임시)
+                    self?.searchResults = books.map { $0.title }
+                case .failure(let error):
+                    print("검색 실패:", error.localizedDescription)
+                    self?.searchResults = []
+                }
+            }
+        }
     }
 }
+
 

--- a/MyBookShelf/MyBookShelf/Network/BookService.swift
+++ b/MyBookShelf/MyBookShelf/Network/BookService.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+class BookService {
+    static let shared = BookService()
+    private init() {}
+
+    private let baseURL = "https://dapi.kakao.com/v3/search/book"
+    private let apiKey = "8d202de167a18183b95c113117709918" // 나중에 .xcconfig로 분리하기
+
+    func searchBooks(query: String, completion: @escaping (Result<[Book], Error>) -> Void) {
+        guard var urlComponents = URLComponents(string: baseURL) else { return }
+        urlComponents.queryItems = [URLQueryItem(name: "query", value: query)]
+        guard let url = urlComponents.url else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("KakaoAK \(apiKey)", forHTTPHeaderField: "Authorization")
+
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            // [디버깅1] 에러 체크
+            if let error = error {
+                print("네트워크 에러 발생:", error.localizedDescription)
+                completion(.failure(error))
+                return
+            }
+
+            // [디버깅2] HTTP 상태 코드 확인
+            if let httpResponse = response as? HTTPURLResponse {
+                print("응답 코드:", httpResponse.statusCode)
+            }
+
+            // [디버깅3] 실제 응답 데이터 확인 (문자열 형태)
+            if let data = data,
+               let jsonString = String(data: data, encoding: .utf8) {
+                print("응답 JSON 미리보기:\n\(jsonString.prefix(300))...\n")
+            }
+
+            guard let data = data else {
+                completion(.failure(NSError(domain: "noData", code: -1)))
+                return
+            }
+
+            do {
+                let decoded = try JSONDecoder().decode(BookSearchResponse.self, from: data)
+                completion(.success(decoded.documents))
+                print("디코딩 성공 — 책 개수:", decoded.documents.count)
+            } catch {
+                print("디코딩 에러:", error)
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+}
+


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!
> 

- Search/Model/`Book` 파일 안에 Book, BookSearchResponse 모델 생성
Book은 책 1권이고, BookSearchResponse는 검색 결과 전체를 감싸는 응답 모델

- Network/`BookService` 구현
검색어를 받아서 API 요청 보내고-> 응답을 Book 배열로 디코딩하도록 만듦

- `SearchViewController`에서 API 호출 연결
검색바에서 검색 버튼을 누르면-> BookService를 통해 API가 호출되도록 연결함
API에서 받아온 결과를 searchResults 에 넣고, 테이블뷰에 표시되게 함

- 아직 테이블뷰 셀 안만들었으니까 디버깅로그 추가해서 확인함


<img width="1016" height="325" alt="스크린샷 2025-10-27 오후 2 50 01" src="https://github.com/user-attachments/assets/fc819dc0-c3c7-4b6c-97e6-fec0a1e6782a" />

정상 작동하는거 확인👍

### 관련 이슈

Closes #9 

### PR 올리기 전 Check List

Merge 대상 브랜치가 올바른가? 네

작업한 코드가 에러 없이 잘 동작하는가? 네
