### PR TITLE
[Feat] #17 - 책 상세정보 모달의 담기버튼 알럿 추가

### DIFF
--- a/MyBookShelf/MyBookShelf/Features/BookDetail/View/BookDetailViewController.swift
+++ b/MyBookShelf/MyBookShelf/Features/BookDetail/View/BookDetailViewController.swift
@@ -1,9 +1,17 @@
 import UIKit
 import SnapKit
 
+// BookDetailViewControllerDelegate 정의
+protocol BookDetailViewControllerDelegate: AnyObject {
+    func didAddBook(_ book: Book)
+}
+
 class BookDetailViewController: UIViewController {
 
     var book: Book?
+    // BookDetailViewController에 delegate 프로퍼티 추가
+    weak var delegate: BookDetailViewControllerDelegate?
+
     
     private let scrollView = UIScrollView()
     private let contentView = UIView()
@@ -75,6 +83,10 @@ class BookDetailViewController: UIViewController {
         addButton.setTitleColor(.white, for: .normal)
         addButton.titleLabel?.font = .boldSystemFont(ofSize: 17)
         addButton.layer.cornerRadius = 12
+        
+        // 담기 버튼 액션 연결
+        addButton.addTarget(self, action: #selector(addBookTapped), for: .touchUpInside)
+
 
         [titleLabel, authorLabel, thumbnailImageView, priceLabel, contentsLabel].forEach {
             contentView.addSubview($0)
@@ -179,5 +191,17 @@ class BookDetailViewController: UIViewController {
     @objc private func dismissModal() {
         dismiss(animated: true, completion: nil)
     }
+    
+    // 담기 버튼 탭 시 실행되는 함수
+    @objc private func addBookTapped() {
+        guard let book = book else { return }
+
+        // 모달을 닫은 뒤에 delegate 실행
+        dismiss(animated: true) {
+            self.delegate?.didAddBook(book)
+        }
+    }
+
+    
 }
 

--- a/MyBookShelf/MyBookShelf/Features/Search/View/SearchViewController.swift
+++ b/MyBookShelf/MyBookShelf/Features/Search/View/SearchViewController.swift
@@ -117,6 +117,10 @@ extension SearchViewController: UITableViewDelegate {
         let selectedBook = viewModel.books[indexPath.row]
         let detailVC = BookDetailViewController()
         detailVC.book = selectedBook
+        
+        // delegate 연결
+        detailVC.delegate = self
+        
         detailVC.modalPresentationStyle = .pageSheet
         present(detailVC, animated: true)
     }
@@ -132,3 +136,15 @@ extension SearchViewController: UISearchBarDelegate {
     }
 }
 
+// delegate 채택
+extension SearchViewController: BookDetailViewControllerDelegate {
+    func didAddBook(_ book: Book) {
+        let alert = UIAlertController(
+            title: nil,  // 타이틀은 뺌
+            message: "『\(book.title ?? "")』 담기 완료!",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
+}


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!
> 

모달에서 담기 버튼을 탭 -> 모달 닫힘 닫히는 시점에 delegate 실행 -> SearchViewController.didAddBook() 호출 -> (책제목) 담기 완료! 알럿 표시

과제 요구사항과 같이 델리게이트 패턴 사용해서 구현함😮‍💨

- BookDetailViewController에서 delegate 프로토콜 정의 (BookDetailViewControllerDelegate)
- SearchViewController가 해당 delegate를 채택
- 모달(BookDetailViewController)에서 “담기” 버튼을 누르면 -> delegate 메서드 호출 후 dismiss
- 모달이 닫히면 -> SearchViewController.didAddBook()에서 알럿 표시

이런식으로 로직을 짰고, 

**모달이 닫히면 -> SearchViewController.didAddBook()에서 알럿 표시** 를구현하는 과정에서, SearchVC에서 alert을 띄우려고 하는 도중에 모달이 바로 내려가는 문제가 발생했다.

DetailVC에서 모달을 완전히 내리고 나서, delegate를 호출하는 방식으로 해결했다.

```swift
// BookDetailViewController.swift
@objc private func addBookTapped() {
    guard let book = book else { return }

    //  먼저 모달을 완전히 닫고,
    dismiss(animated: true) { [weak self] in
        guard let self = self else { return }
        // 닫힌 다음에 delegate에게 알려서 alert를 띄우게 한다.
        self.delegate?.didAddBook(book)
    }
}
```

작업완료한 뷰는 아래와 같다.

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-28 at 14 39 45" src="https://github.com/user-attachments/assets/d3e76918-86a4-4d0f-9228-678ecebc6a3d" />


### 관련 이슈

Closes #17 

### PR 올리기 전 Check List

Merge 대상 브랜치가 올바른가? 네

작업한 코드가 에러 없이 잘 동작하는가? 네
