### PR TITLE
[Feat] #29 - 담은 책 스와이프 삭제 추가

### DIFF
--- a/MyBookShelf/MyBookShelf/Features/SavedBooks/View/SavedBooksViewController.swift
+++ b/MyBookShelf/MyBookShelf/Features/SavedBooks/View/SavedBooksViewController.swift
@@ -16,6 +16,9 @@ class SavedBooksViewController: UIViewController {
         setupLayout()
         bindViewModel()
         viewModel.fetchBooks()
+        
+        tableView.delegate = self
+
     }
     
     private func setupUI() {
@@ -24,7 +27,7 @@ class SavedBooksViewController: UIViewController {
         tableView.rowHeight = 90
         view.addSubview(tableView)
         
-        emptyLabel.text = "아직 담은 책이 없습니다 📚"
+        emptyLabel.text = "아직 담은 책이 없습니다."
         emptyLabel.textAlignment = .center
         emptyLabel.textColor = .secondaryLabel
         view.addSubview(emptyLabel)
@@ -54,7 +57,7 @@ class SavedBooksViewController: UIViewController {
     }
 }
 
-// MARK: - UITableViewDataSource
+// UITableViewDataSource
 extension SavedBooksViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         viewModel.savedBooks.count
@@ -69,4 +72,24 @@ extension SavedBooksViewController: UITableViewDataSource {
         return cell
     }
 }
+
+// UITableViewDelegate
+extension SavedBooksViewController: UITableViewDelegate {
+    // 스와이프 삭제 액션 추가
+    func tableView(_ tableView: UITableView,
+                   trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath)
+    -> UISwipeActionsConfiguration? {
+
+        let deleteAction = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completionHandler in
+            guard let self = self else { return }
+
+            let bookToDelete = self.viewModel.savedBooks[indexPath.row]
+            self.viewModel.deleteBook(bookToDelete)   
+            completionHandler(true)
+        }
+
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+}
+
 

--- a/MyBookShelf/MyBookShelf/Features/SavedBooks/ViewModel/SavedBooksViewModel.swift
+++ b/MyBookShelf/MyBookShelf/Features/SavedBooks/ViewModel/SavedBooksViewModel.swift
@@ -33,5 +33,18 @@ class SavedBooksViewModel {
             print("코어데이터 Save 실패:", error.localizedDescription)
         }
     }
+    
+    func deleteBook(_ book: SavedBookEntity) {
+        context.delete(book)
+        do {
+            try context.save()
+            print("책 삭제 성공: \(book.title ?? "")")
+            fetchBooks()   
+        } catch {
+            print("삭제 실패:", error.localizedDescription)
+        }
+    }
+
+
 }
 


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!
> 

`SavedBooksViewController.swift`수정
- `trailingSwipeActionsConfigurationForRowAt` 추가

`SavedBooksViewModel.swift`
- deleteBook(_:) 함수 추가
- 코어데이터 삭제하고 fetchBooks() 자동 호출

<동작 흐름>
책 스와이프 시 "삭제"버튼 보임-> 삭제 선택 시 코어데이터에서 해당 책 엔티티가 삭제됨 -> 테이블뷰 자동 새로고침 -> 남은 책 없을 경우에 "아직 담은 책이 없습니다." 문구 표시

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-29 at 10 28 31" src="https://github.com/user-attachments/assets/729fa551-b863-4534-993f-325097d5c5a6" />

### 관련 이슈

Closes #29 

### PR 올리기 전 Check List

Merge 대상 브랜치가 올바른가? 네

작업한 코드가 에러 없이 잘 동작하는가? 네
