### PR TITLE
[Design] #38 - 검색결과 상단에 최근본책 섹션 추가

### DIFF
--- a/MyBookShelf/MyBookShelf/Features/Search/View/RecentBookItemCell.swift
+++ b/MyBookShelf/MyBookShelf/Features/Search/View/RecentBookItemCell.swift
@@ -1,0 +1,22 @@
+import UIKit
+import SnapKit
+
+class RecentBookItemCell: UICollectionViewCell {
+    private let thumbnailView = UIView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(thumbnailView)
+        thumbnailView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        thumbnailView.backgroundColor = .systemGray5
+        thumbnailView.layer.cornerRadius = 8
+        thumbnailView.clipsToBounds = true
+    }
+    
+    required init?(coder: NSCoder) { fatalError() }
+    
+    func configurePlaceholder() {
+        // 나중에 이미지뷰로 바꿀 예정
+    }
+}
+

--- a/MyBookShelf/MyBookShelf/Features/Search/View/RecentlyViewedBooksCell.swift
+++ b/MyBookShelf/MyBookShelf/Features/Search/View/RecentlyViewedBooksCell.swift
@@ -1,0 +1,47 @@
+import UIKit
+import SnapKit
+
+class RecentlyViewedBooksCell: UITableViewCell {
+    static let identifier = "RecentlyViewedBooksCell"
+    
+    private let collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.itemSize = CGSize(width: 70, height: 100)
+        layout.minimumLineSpacing = 10
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        cv.showsHorizontalScrollIndicator = false
+        cv.backgroundColor = .clear
+        return cv
+    }()
+    
+    private var placeholderCount = 5
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.addSubview(collectionView)
+        collectionView.snp.makeConstraints { $0.edges.equalToSuperview().inset(10) }
+        collectionView.dataSource = self
+        collectionView.register(RecentBookItemCell.self, forCellWithReuseIdentifier: "RecentBookItemCell")
+    }
+    
+    required init?(coder: NSCoder) { fatalError() }
+    
+    func configurePlaceholder() {
+        placeholderCount = 5
+        collectionView.reloadData()
+    }
+}
+
+extension RecentlyViewedBooksCell: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return placeholderCount
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "RecentBookItemCell", for: indexPath) as! RecentBookItemCell
+        cell.configurePlaceholder()
+        return cell
+    }
+}
+


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #38 

원래 검색화면은 테이블뷰 셀로 되어있었는데

컬렉션뷰로 전체구조를 변경하지않고
테이블뷰 섹션 셀 안에 컬렉션뷰를 넣어서 부분적으로 가로 스크롤을 가능하게 함

**현재 구조:**

```
테이블뷰
├─ [Section 0: 최근 본 책]
│   ┌──────────────────────────────────┐
│   │ 📕📕📕📕📕  <- 컬렉션뷰(가로 스크롤) │
│   └──────────────────────────────────┘
│
├─ [Section 1: 검색 결과]
│   ├─ "책 1"
│   ├─ "책 2"
│   ├─ "책 3"
│   └─ ...
```

```
SearchViewController
 └── UITableView
      ├── Section 0 -> RecentlyViewedBooksCell (최근 본 책)
      │       └── UICollectionView (RecentBookItemCell 들어감)
      └── Section 1 -> BookTableViewCell (검색 결과 리스트)

```
<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-29 at 17 16 28" src="https://github.com/user-attachments/assets/71088ad7-2dea-4d25-8367-67e523a7e168" />

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-29 at 17 15 51" src="https://github.com/user-attachments/assets/04cb9e7b-0da7-424d-a81e-a4757dcc1893" />

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
