### PR TITLE
[Feat] #40 - 최근 본 책 아이템 추가

### DIFF
--- a/MyBookShelf/MyBookShelf/Features/Search/View/RecentBookItemCell.swift
+++ b/MyBookShelf/MyBookShelf/Features/Search/View/RecentBookItemCell.swift
@@ -2,21 +2,28 @@ import UIKit
 import SnapKit
 
 class RecentBookItemCell: UICollectionViewCell {
-    private let thumbnailView = UIView()
-    
+    private let imageView = UIImageView()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
-        contentView.addSubview(thumbnailView)
-        thumbnailView.snp.makeConstraints { $0.edges.equalToSuperview() }
-        thumbnailView.backgroundColor = .systemGray5
-        thumbnailView.layer.cornerRadius = 8
-        thumbnailView.clipsToBounds = true
+        contentView.addSubview(imageView)
+        imageView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        imageView.layer.cornerRadius = 0
+        imageView.clipsToBounds = true
+        imageView.contentMode = .scaleAspectFill
     }
-    
+
     required init?(coder: NSCoder) { fatalError() }
-    
-    func configurePlaceholder() {
-        // 나중에 이미지뷰로 바꿀 예정
+
+    func configure(with urlString: String) {
+        if let url = URL(string: urlString),
+           let data = try? Data(contentsOf: url) {
+            imageView.image = UIImage(data: data)
+        } else {
+            imageView.image = UIImage(systemName: "book")
+            imageView.tintColor = .systemGray3
+        }
     }
 }
+
 

--- a/MyBookShelf/MyBookShelf/Features/Search/View/RecentlyViewedBooksCell.swift
+++ b/MyBookShelf/MyBookShelf/Features/Search/View/RecentlyViewedBooksCell.swift
@@ -4,6 +4,13 @@ import SnapKit
 class RecentlyViewedBooksCell: UITableViewCell {
     static let identifier = "RecentlyViewedBooksCell"
     
+    private var recentBooks: [[String: String]] = []
+
+    func configure(with books: [[String: String]]) {
+        self.recentBooks = books
+        collectionView.reloadData()
+    }
+
     private let collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -20,7 +27,10 @@ class RecentlyViewedBooksCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         contentView.addSubview(collectionView)
-        collectionView.snp.makeConstraints { $0.edges.equalToSuperview().inset(10) }
+        collectionView.snp.makeConstraints { $0.edges.equalToSuperview().inset(10)
+            $0.height.equalTo(150)
+        }
+        
         collectionView.dataSource = self
         collectionView.register(RecentBookItemCell.self, forCellWithReuseIdentifier: "RecentBookItemCell")
     }
@@ -35,13 +45,15 @@ class RecentlyViewedBooksCell: UITableViewCell {
 
 extension RecentlyViewedBooksCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return placeholderCount
+        return recentBooks.count
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "RecentBookItemCell", for: indexPath) as! RecentBookItemCell
-        cell.configurePlaceholder()
+        let book = recentBooks[indexPath.item]
+        cell.configure(with: book["thumbnailURL"] ?? "")
         return cell
     }
+
 }
 

--- a/MyBookShelf/MyBookShelf/Features/Search/View/SearchViewController.swift
+++ b/MyBookShelf/MyBookShelf/Features/Search/View/SearchViewController.swift
@@ -11,6 +11,10 @@ class SearchViewController: UIViewController {
     // 뷰모델
     private let viewModel = SearchViewModel()
     
+    // 최근본책
+    private var recentBooks: [[String: String]] = []
+
+    
     // 라이프싸이클
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,6 +25,13 @@ class SearchViewController: UIViewController {
         
         bindViewModel()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        loadRecentBooks()
+        tableView.reloadData()
+    }
+
     
     // 뷰모델 바인딩
     private func bindViewModel() {
@@ -34,6 +45,12 @@ class SearchViewController: UIViewController {
             print("검색 실패:", errorMessage)
         }
     }
+    
+    private func loadRecentBooks() {
+        let defaults = UserDefaults.standard
+        recentBooks = defaults.array(forKey: "recentBooks") as? [[String: String]] ?? []
+    }
+
 }
 
 // UI 셋업
@@ -109,9 +126,8 @@ extension SearchViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == 0 {
-            // 최근 본 책 섹션 (지금은 임시 UI만 있음)
             let cell = tableView.dequeueReusableCell(withIdentifier: RecentlyViewedBooksCell.identifier, for: indexPath) as! RecentlyViewedBooksCell
-            cell.configurePlaceholder()
+            cell.configure(with: recentBooks)
             return cell
         } else {
             // 기존 검색 결과 섹션
@@ -140,7 +156,7 @@ extension SearchViewController: UITableViewDelegate {
         let label = UILabel()
         label.font = .systemFont(ofSize: 20, weight: .semibold)
         label.textColor = .systemGray
-        label.text = section == 0 ? "최근 본 책 " : "검색 결과 🔍"
+        label.text = section == 0 ? "최근 본 책 " : "검색 결과"
         
         headerView.addSubview(label)
         label.snp.makeConstraints { make in


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

책 상세화면을 한 번이라도 열었을 때 유저디폴트에 저장하고,
유저디폴트에서 최근 본 책을 불러와서 테이블뷰에 표시하고,
최근 본 책 리스트를 다시 컬렉션뷰로 표시함 

아이템셀은 UIImageView로 변경해서 썸네일로 표시함

- Closes #40 


<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-30 at 10 59 49" src="https://github.com/user-attachments/assets/dbee4039-4c78-49e1-a4bd-911e3f06738b" />

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

**1. 책 상세모달을 닫았을 때 UI 업데이트가 바로 되지않고, 다른 탭을 갔다가 오면 UI 업데이트가 되어있음.**

```swift
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    loadRecentBooks()
    tableView.reloadData()
}
```
```swift
private var recentBooks: [[String: String]] = []

func configure(with books: [[String: String]]) {
    self.recentBooks = books
    collectionView.reloadData()
}
```

둘다 reloadData()는 추가가 되어있는데, 모달닫고나서도 서치뷰컨트롤러가 화면에 계속 떠있는 상태여서
viewWillAppear가 호출이 안되는 것 같음 아마도

=> NotificationCenter 사용해서 픽스할 예정

**2. 이미지 다운로드 끝날 때까지 UI 스레드 멈춰서 이런 경고가 뜸..**
<img width="454" height="345" alt="스크린샷 2025-10-30 오전 11 07 04" src="https://github.com/user-attachments/assets/6a47b9e5-7d2a-4d1a-9fb2-df056326c92a" />

=> 비동기 방식으로 다시 변경해볼 예정

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
